### PR TITLE
Ai classification tags

### DIFF
--- a/src/lib/sync/content-analyzer.ts
+++ b/src/lib/sync/content-analyzer.ts
@@ -1,9 +1,49 @@
 // LLM 内容分析模块
 import type { GitHubIssuePayload } from './types'
 
-const TONE_TAGS = ['温情', '反转', '抽象', '自嘲', '讽刺', '励志']
-const THEME_TAGS = ['职场', '恋爱', '学生', '社畜', '单身', '家庭', '朋友']
-const STYLE_TAGS = ['对话体', '独白体', '故事体', '排比', '谐音梗']
+const TONE_TAGS = [
+  '温情',
+  '反转',
+  '抽象',
+  '自嘲',
+  '讽刺',
+  '励志',
+  '无厘头',
+  '黑色幽默',
+  '暴躁',
+  '尴尬',
+  '甜蜜',
+  '崩溃',
+]
+const THEME_TAGS = [
+  '职场',
+  '恋爱',
+  '学生',
+  '社畜',
+  '单身',
+  '家庭',
+  '朋友',
+  '美食',
+  '外卖',
+  '肯德基',
+  '考试',
+  '租房',
+  '加班',
+  '游戏',
+  '旅行',
+]
+const STYLE_TAGS = [
+  '对话体',
+  '独白体',
+  '故事体',
+  '排比',
+  '谐音梗',
+  '反问',
+  '夸张',
+  '押韵',
+  '口号体',
+  '通知体',
+]
 const FALLBACK_TAG = '其他'  // 兜底标签，表示已分类但没有合适标签
 const ALL_TAGS = new Set([...TONE_TAGS, ...THEME_TAGS, ...STYLE_TAGS, FALLBACK_TAG])
 

--- a/src/lib/sync/content-analyzer.ts
+++ b/src/lib/sync/content-analyzer.ts
@@ -14,6 +14,12 @@ const TONE_TAGS = [
   '尴尬',
   '甜蜜',
   '崩溃',
+  '治愈',
+  '魔性',
+  '焦虑',
+  '摆烂',
+  '冷幽默',
+  '心酸',
 ]
 const THEME_TAGS = [
   '职场',
@@ -25,12 +31,18 @@ const THEME_TAGS = [
   '朋友',
   '美食',
   '外卖',
-  '肯德基',
   '考试',
   '租房',
   '加班',
   '游戏',
   '旅行',
+  '通勤',
+  '工资',
+  '相亲',
+  '节日',
+  '熬夜',
+  '天气',
+  '宠物',
 ]
 const STYLE_TAGS = [
   '对话体',
@@ -43,6 +55,11 @@ const STYLE_TAGS = [
   '押韵',
   '口号体',
   '通知体',
+  '吐槽体',
+  '清单体',
+  '采访体',
+  '直播体',
+  '自问自答',
 ]
 const FALLBACK_TAG = '其他'  // 兜底标签，表示已分类但没有合适标签
 const ALL_TAGS = new Set([...TONE_TAGS, ...THEME_TAGS, ...STYLE_TAGS, FALLBACK_TAG])


### PR DESCRIPTION
Add more tags for AI content classification.

Expanded the `TONE_TAGS`, `THEME_TAGS`, and `STYLE_TAGS` collections to provide a richer set of labels for AI classification.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6fe0b4c-30cb-404b-ab74-7ee6e2920656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6fe0b4c-30cb-404b-ab74-7ee6e2920656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only change that broadens allowed classification labels; main risk is downstream consumers not expecting new tag values.
> 
> **Overview**
> Expands the tag taxonomy used by `src/lib/sync/content-analyzer.ts` by adding many new options across `TONE_TAGS`, `THEME_TAGS`, and `STYLE_TAGS`, broadening what the LLM can legally return.
> 
> Because tags are validated against `ALL_TAGS` and the tool-call enum, this effectively widens the accepted/normalized label set without changing the analysis flow or limits (still max 3 tags, fallback to `其他`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98a8fe8779e4dc100322b094634f088f869f3df7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->