### PR TITLE
feat: 🗄️ SqlSnapshotProvider 默认装载 snapshot.sql（兑现 §5）

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx'],
+  // 把 sql.js 的 wasm 强制打进所有 lambda（SqlSnapshotProvider 通过 fs.readFileSync 读取）
+  outputFileTracingIncludes: {
+    '/**': ['./node_modules/sql.js/dist/sql-wasm.wasm'],
+  },
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-dom": "19.2.4",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "sql.js": "^1.14.1",
         "swr": "^2.3.6",
         "typescript": "^5.3.3",
         "unist-util-visit": "^5.0.0"
@@ -33,6 +34,7 @@
         "@types/node": "^20",
         "@types/react": "19.2.10",
         "@types/react-dom": "19.2.3",
+        "@types/sql.js": "^1.4.11",
         "baseline-browser-mapping": "^2.9.19",
         "eslint": "^9.39.2",
         "eslint-config-next": "16.1.6",
@@ -4286,6 +4288,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4371,6 +4380,17 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -11224,6 +11244,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "sql.js": "^1.14.1",
     "swr": "^2.3.6",
     "typescript": "^5.3.3",
     "unist-util-visit": "^5.0.0"
@@ -38,6 +39,7 @@
     "@types/node": "^20",
     "@types/react": "19.2.10",
     "@types/react-dom": "19.2.3",
+    "@types/sql.js": "^1.4.11",
     "baseline-browser-mapping": "^2.9.19",
     "eslint": "^9.39.2",
     "eslint-config-next": "16.1.6",

--- a/src/lib/data-access/index.ts
+++ b/src/lib/data-access/index.ts
@@ -1,24 +1,33 @@
 // 数据访问层入口
 import { NeonProvider } from './neon-provider'
 import { SnapshotProvider } from './snapshot-provider'
+import { SqlSnapshotProvider } from './sql-snapshot-provider'
 import { DataProvider } from './types'
 
 export * from './types'
 export { NeonProvider } from './neon-provider'
 export { SnapshotProvider } from './snapshot-provider'
+export { SqlSnapshotProvider } from './sql-snapshot-provider'
 
 // 创建数据提供者实例
-// Phase B：默认读快照（去库，不依赖 DATABASE_URL）；DATA_PROVIDER=neon 可回退到 Neon。
-// 确定性回滚以 git revert 本提交为准（不依赖运行时 env 访问）。
+// 默认走 SqlSnapshotProvider（sql.js 装载 vme-content/data/snapshot.sql，
+// 兑现 architecture §5「无正文索引 + 正文按需」）。降级梯队：
+// - DATA_PROVIDER=snapshot  → SnapshotProvider（拉 month JSON，去库 Phase B 路径）
+// - DATA_PROVIDER=neon      → NeonProvider（应急回退；Phase C 后非默认）
+// 确定性回滚仍以 git revert 为准。
 function createDataProvider(): DataProvider {
-  if (process.env.DATA_PROVIDER === 'neon') {
+  const choice = process.env.DATA_PROVIDER
+  if (choice === 'neon') {
     const databaseUrl = process.env.DATABASE_URL
     if (!databaseUrl) {
       throw new Error('DATABASE_URL environment variable is required (DATA_PROVIDER=neon)')
     }
     return new NeonProvider(databaseUrl)
   }
-  return new SnapshotProvider()
+  if (choice === 'snapshot') {
+    return new SnapshotProvider()
+  }
+  return new SqlSnapshotProvider()
 }
 
 // 单例模式导出

--- a/src/lib/data-access/sql-snapshot-provider.test.ts
+++ b/src/lib/data-access/sql-snapshot-provider.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SqlSnapshotProvider } from './sql-snapshot-provider'
+
+const summary = {
+  totalItems: 4,
+  totalContributors: 2,
+  months: [
+    { month: '2026-01', count: 2 },
+    { month: '2026-02', count: 2 },
+  ],
+  contributors: [
+    { username: 'alice', count: 3 },
+    { username: 'bob', count: 1 },
+  ],
+  topContributors: [{ username: 'alice', count: 3 }],
+  updatedAt: '2026-02-01T00:00:00.000Z',
+}
+
+// 4 条 items（与 SnapshotProvider 测试同等覆盖），item_tags 5 行
+const snapshotSql = `
+-- vme snapshot fixture
+CREATE TABLE items (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  author TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  reactions INTEGER NOT NULL,
+  type TEXT NOT NULL CHECK (type IN ('text','meme'))
+);
+CREATE INDEX idx_items_author ON items(author);
+CREATE INDEX idx_items_type ON items(type);
+CREATE INDEX idx_items_created ON items(created_at);
+CREATE INDEX idx_items_reactions ON items(reactions);
+
+CREATE TABLE item_tags (
+  item_id TEXT NOT NULL,
+  tag TEXT NOT NULL,
+  PRIMARY KEY (item_id, tag)
+);
+CREATE INDEX idx_item_tags_tag ON item_tags(tag);
+
+BEGIN;
+INSERT INTO items VALUES ('a1','hi','hello world','alice',${new Date('2026-01-10T00:00:00.000Z').getTime()},5,'text');
+INSERT INTO items VALUES ('a2','m','meme ![x](http://i/x.png)','alice',${new Date('2026-01-20T00:00:00.000Z').getTime()},9,'meme');
+INSERT INTO items VALUES ('a3','s','short','alice',${new Date('2026-02-15T00:00:00.000Z').getTime()},1,'text');
+INSERT INTO items VALUES ('b1','c','another text about cats','bob',${new Date('2026-02-05T00:00:00.000Z').getTime()},2,'text');
+INSERT INTO item_tags VALUES ('a1','恋爱');
+INSERT INTO item_tags VALUES ('a1','谐音梗');
+INSERT INTO item_tags VALUES ('a2','荒诞');
+INSERT INTO item_tags VALUES ('b1','恋爱');
+COMMIT;
+`
+
+function mockFetchOk() {
+  const fn = vi.fn(async (url: string) => {
+    if (url.endsWith('/snapshot.sql')) {
+      return { ok: true, text: async () => snapshotSql } as Response
+    }
+    if (url.endsWith('/summary.json')) {
+      return { ok: true, json: async () => summary } as Response
+    }
+    return { ok: false, status: 404, text: async () => '', json: async () => ({}) } as Response
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('SqlSnapshotProvider', () => {
+  it('getItems：默认按 created_at DESC 分页', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const r = await p.getItems({ page: 1, limit: 10 })
+    expect(r.total).toBe(4)
+    expect(r.items.map((i) => i.id)).toEqual(['a3', 'b1', 'a2', 'a1'])
+  })
+
+  it('getItems：author 过滤', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const r = await p.getItems({ author: 'alice', page: 1, limit: 10 })
+    expect(r.total).toBe(3)
+    expect(r.items.map((i) => i.id).sort()).toEqual(['a1', 'a2', 'a3'])
+  })
+
+  it('getItems：type 过滤', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const r = await p.getItems({ type: 'meme', page: 1, limit: 10 })
+    expect(r.total).toBe(1)
+    expect(r.items[0].id).toBe('a2')
+  })
+
+  it('getItems：tag 过滤（走 item_tags join）', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const r = await p.getItems({ tag: '恋爱', page: 1, limit: 10 })
+    expect(r.total).toBe(2)
+    expect(r.items.map((i) => i.id).sort()).toEqual(['a1', 'b1'])
+  })
+
+  it('getItems：search 过滤（LIKE 不区分大小写）', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const r = await p.getItems({ search: 'CATS', page: 1, limit: 10 })
+    expect(r.items.map((i) => i.id)).toEqual(['b1'])
+  })
+
+  it('getItems：sortBy reactions DESC', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const r = await p.getItems({ sortBy: 'reactions', order: 'desc', page: 1, limit: 10 })
+    expect(r.items.map((i) => i.id)).toEqual(['a2', 'a1', 'b1', 'a3'])
+  })
+
+  it('getItems：item 含 tags 数组', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const r = await p.getItems({ author: 'alice', page: 1, limit: 10 })
+    const a1 = r.items.find((i) => i.id === 'a1')!
+    expect(a1.tags?.sort()).toEqual(['恋爱', '谐音梗'])
+    const a3 = r.items.find((i) => i.id === 'a3')!
+    expect(a3.tags).toEqual([])
+  })
+
+  it('getItems：item 派生 author.avatarUrl / url', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const r = await p.getItems({ author: 'alice', page: 1, limit: 1 })
+    expect(r.items[0].author.username).toBe('alice')
+    expect(r.items[0].author.avatarUrl).toBe('https://github.com/alice.png')
+    expect(r.items[0].author.url).toBe('https://github.com/alice')
+  })
+
+  it('getItemById：命中', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const it = await p.getItemById('a1')
+    expect(it?.id).toBe('a1')
+    expect(it?.tags?.sort()).toEqual(['恋爱', '谐音梗'])
+  })
+
+  it('getItemById：未命中返回 null', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    expect(await p.getItemById('nope')).toBeNull()
+  })
+
+  it('getStats：用 summary.json 派生', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const s = await p.getStats()
+    expect(s.totalItems).toBe(4)
+    expect(s.totalContributors).toBe(2)
+    expect(s.contributors.map((c) => c.username)).toEqual(['alice', 'bob'])
+    expect(s.contributors[0].avatarUrl).toBe('https://github.com/alice.png')
+  })
+
+  it('getTopTags：按 count DESC', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const tags = await p.getTopTags(10)
+    expect(tags.find((t) => t.tag === '恋爱')?.count).toBe(2)
+    expect(tags.find((t) => t.tag === '谐音梗')?.count).toBe(1)
+    expect(tags.find((t) => t.tag === '荒诞')?.count).toBe(1)
+  })
+
+  it('searchItems：相同 LIKE 行为', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const items = await p.searchItems('hello')
+    expect(items.map((i) => i.id)).toEqual(['a1'])
+  })
+
+  it('getFeaturedItems：每作者一条最佳 text + excludeId', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    // alice text 段子：a1(reactions=5)/a3(=1)；最佳 a1。b1 text reactions=2。期望按 reactions desc：a1, b1
+    const items = await p.getFeaturedItems(3)
+    expect(items.map((i) => i.id)).toEqual(['a1', 'b1'])
+
+    // 排除 a1 后，alice 最佳变 a3(reactions=1)
+    const items2 = await p.getFeaturedItems(3, 'a1')
+    expect(items2.map((i) => i.id)).toEqual(['b1', 'a3'])
+  })
+
+  it('getRandomItem：返回非空（type=text 时只在 text 子集）', async () => {
+    mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    const r = await p.getRandomItem('text')
+    expect(['a1', 'a3', 'b1']).toContain(r?.id)
+  })
+
+  it('graceful-degrade：fetch 失败、无缓存 → 返回空集合而非抛错', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500 }) as Response),
+    )
+    const p = new SqlSnapshotProvider()
+    const r = await p.getItems({})
+    expect(r.total).toBe(0)
+    expect(r.items).toEqual([])
+  })
+
+  it('TTL 命中：5 分钟内复用 model，不再 fetch', async () => {
+    const fn = mockFetchOk()
+    const p = new SqlSnapshotProvider()
+    await p.getItems({})
+    const callsAfterFirst = fn.mock.calls.length
+    await p.getItems({ author: 'alice' })
+    expect(fn.mock.calls.length).toBe(callsAfterFirst)
+  })
+})

--- a/src/lib/data-access/sql-snapshot-provider.ts
+++ b/src/lib/data-access/sql-snapshot-provider.ts
@@ -1,0 +1,406 @@
+// SQL 快照数据提供者：拉 vme-content/data/snapshot.sql + sql.js 内存 SQLite 装载 + 索引查询。
+// 兑现 architecture §5「无正文索引 + 正文按需」的查询形态：API 暴露 SQL 查询粒度，
+// 调用方按需取，所有过滤维度（author/tag/type/search）走索引。
+//
+// 与 SnapshotProvider 区别：
+// - SnapshotProvider 拉 month JSON + 内存 records 数组，过滤是 O(n) 线性扫
+// - SqlSnapshotProvider 拉单文件 snapshot.sql + SQLite 索引查询，cold start 更短、warm 查询亚毫秒
+//
+// 降级语义对齐 SnapshotProvider：fetch 失败回退上次 good model，无 model 时回退空集合。
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import initSqlJs, { type Database, type SqlJsStatic } from 'sql.js'
+import { IKfcItem, Summary, Contributor } from '@/types'
+import { DataProvider, GetItemsParams, PaginatedItems, TopTag } from './types'
+
+const DEFAULT_BASE =
+  process.env.SNAPSHOT_BASE_URL || 'https://raw.githubusercontent.com/vme-im/vme-content/main'
+
+const MODEL_TTL_MS = 5 * 60 * 1000
+const FETCH_TIMEOUT_MS = 15000
+
+function getAvatarUrl(u: string): string {
+  return `https://github.com/${u}.png`
+}
+function getUserUrl(u: string): string {
+  return `https://github.com/${u}`
+}
+
+interface SummaryFile {
+  totalItems: number
+  totalContributors: number
+  months: { month: string; count: number }[]
+  contributors: { username: string; count: number }[]
+  topContributors?: { username: string; count: number }[]
+  updatedAt: string
+}
+
+interface ItemRow {
+  id: string
+  title: string
+  body: string
+  author: string
+  created_at: number
+  reactions: number
+  type: 'text' | 'meme'
+}
+
+interface Model {
+  db: Database
+  summary: SummaryFile | null
+}
+
+let sqlJsInstance: SqlJsStatic | null = null
+
+async function getSqlJs(): Promise<SqlJsStatic> {
+  if (sqlJsInstance) return sqlJsInstance
+  const wasmPath = path.join(process.cwd(), 'node_modules', 'sql.js', 'dist', 'sql-wasm.wasm')
+  const wasmBinary = readFileSync(wasmPath)
+  sqlJsInstance = await initSqlJs({ wasmBinary })
+  return sqlJsInstance
+}
+
+async function fetchText(url: string): Promise<string> {
+  const controller = new AbortController()
+  const t = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const res = await fetch(url, { cache: 'no-store', signal: controller.signal })
+    if (!res.ok) throw new Error(`fetch ${url} -> ${res.status}`)
+    return await res.text()
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const controller = new AbortController()
+  const t = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const res = await fetch(url, { cache: 'no-store', signal: controller.signal })
+    if (!res.ok) throw new Error(`fetch ${url} -> ${res.status}`)
+    return (await res.json()) as T
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+function rowToItem(r: ItemRow, tags: string[]): IKfcItem {
+  return {
+    id: r.id,
+    title: r.title,
+    url: `https://github.com/vme-im/vme-content/issues/${r.id}`,
+    body: r.body,
+    createdAt: new Date(r.created_at).toISOString(),
+    updatedAt: new Date(r.created_at).toISOString(),
+    author: {
+      username: r.author,
+      avatarUrl: getAvatarUrl(r.author),
+      url: getUserUrl(r.author),
+    },
+    reactions: { totalCount: r.reactions },
+    tags,
+  }
+}
+
+function toContributor(c: { username: string; count: number }): Contributor {
+  return {
+    username: c.username,
+    count: c.count,
+    avatarUrl: getAvatarUrl(c.username),
+    url: getUserUrl(c.username),
+  }
+}
+
+// 查询 db 拿到一组 item id 对应的 tags（一次查、内存分组）
+function queryTagsForIds(db: Database, ids: string[]): Map<string, string[]> {
+  const map = new Map<string, string[]>()
+  if (ids.length === 0) return map
+  // IN (?, ?, ...) 动态参数数量
+  const placeholders = ids.map(() => '?').join(',')
+  const stmt = db.prepare(
+    `SELECT item_id, tag FROM item_tags WHERE item_id IN (${placeholders}) ORDER BY item_id, tag`,
+  )
+  stmt.bind(ids)
+  while (stmt.step()) {
+    const row = stmt.getAsObject() as { item_id: string; tag: string }
+    const arr = map.get(row.item_id) || []
+    arr.push(row.tag)
+    map.set(row.item_id, arr)
+  }
+  stmt.free()
+  return map
+}
+
+function readItemRows(db: Database, sql: string, params: unknown[]): ItemRow[] {
+  const stmt = db.prepare(sql)
+  if (params.length) stmt.bind(params as never)
+  const rows: ItemRow[] = []
+  while (stmt.step()) rows.push(stmt.getAsObject() as unknown as ItemRow)
+  stmt.free()
+  return rows
+}
+
+function readScalar<T = number>(db: Database, sql: string, params: unknown[] = []): T {
+  const stmt = db.prepare(sql)
+  if (params.length) stmt.bind(params as never)
+  stmt.step()
+  const v = stmt.get()[0] as T
+  stmt.free()
+  return v
+}
+
+export class SqlSnapshotProvider implements DataProvider {
+  private base: string
+  private cache: { model: Model; ts: number } | null = null
+  private inflight: Promise<Model> | null = null
+
+  constructor(baseUrl: string = DEFAULT_BASE) {
+    this.base = baseUrl.replace(/\/$/, '')
+  }
+
+  private async loadModel(): Promise<Model> {
+    const SQL = await getSqlJs()
+    // 并行 fetch
+    const [sqlText, summary] = await Promise.all([
+      fetchText(`${this.base}/data/snapshot.sql`),
+      fetchJson<SummaryFile>(`${this.base}/data/summary.json`).catch(() => null),
+    ])
+    const db = new SQL.Database()
+    db.exec(sqlText)
+    return { db, summary }
+  }
+
+  private async getModel(): Promise<Model> {
+    const now = Date.now()
+    if (this.cache && now - this.cache.ts < MODEL_TTL_MS) {
+      return this.cache.model
+    }
+    if (this.inflight) return this.inflight
+    this.inflight = (async () => {
+      try {
+        const model = await this.loadModel()
+        // 旧 db 主动关闭释放
+        if (this.cache) this.cache.model.db.close()
+        this.cache = { model, ts: Date.now() }
+        return model
+      } catch (e) {
+        console.error('SqlSnapshotProvider: load failed', e)
+        if (this.cache) return this.cache.model
+        // 没有任何缓存：返回一个空 db，避免整站 500
+        const SQL = await getSqlJs()
+        const emptyDb = new SQL.Database()
+        emptyDb.exec(
+          'CREATE TABLE items (id TEXT PRIMARY KEY, title TEXT, body TEXT, author TEXT, created_at INTEGER, reactions INTEGER, type TEXT);' +
+            'CREATE TABLE item_tags (item_id TEXT, tag TEXT);',
+        )
+        return { db: emptyDb, summary: null }
+      } finally {
+        this.inflight = null
+      }
+    })()
+    return this.inflight
+  }
+
+  async getItems(params: GetItemsParams): Promise<PaginatedItems> {
+    const {
+      page = 1,
+      limit = 20,
+      sortBy = 'createdAt',
+      order = 'desc',
+      author,
+      type,
+      tag,
+      search,
+    } = params
+    const { db } = await this.getModel()
+
+    const wheres: string[] = []
+    const bindParams: unknown[] = []
+    const fromClause = tag ? 'items i JOIN item_tags t ON i.id = t.item_id' : 'items i'
+    if (tag) {
+      wheres.push('t.tag = ?')
+      bindParams.push(tag)
+    }
+    if (author) {
+      wheres.push('i.author = ?')
+      bindParams.push(author)
+    }
+    if (type) {
+      wheres.push('i.type = ?')
+      bindParams.push(type)
+    }
+    if (search) {
+      wheres.push('(LOWER(i.title) LIKE ? OR LOWER(i.body) LIKE ?)')
+      const q = `%${search.toLowerCase()}%`
+      bindParams.push(q, q)
+    }
+    const whereSql = wheres.length ? `WHERE ${wheres.join(' AND ')}` : ''
+
+    const orderField = sortBy === 'reactions' || sortBy === 'hot' ? 'i.reactions' : 'i.created_at'
+    const direction = (order || 'desc').toLowerCase() === 'asc' ? 'ASC' : 'DESC'
+    const offset = Math.max(0, (page - 1) * limit)
+
+    const total = readScalar<number>(
+      db,
+      `SELECT COUNT(*) FROM ${fromClause} ${whereSql}`,
+      bindParams,
+    )
+
+    const rowsSql = `SELECT i.id, i.title, i.body, i.author, i.created_at, i.reactions, i.type FROM ${fromClause} ${whereSql} ORDER BY ${orderField} ${direction}, i.created_at DESC LIMIT ? OFFSET ?`
+    const rows = readItemRows(db, rowsSql, [...bindParams, limit, offset])
+    const tagsMap = queryTagsForIds(
+      db,
+      rows.map((r) => r.id),
+    )
+    const items = rows.map((r) => rowToItem(r, tagsMap.get(r.id) ?? []))
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    }
+  }
+
+  async getRandomItem(type?: 'text' | 'meme'): Promise<IKfcItem | null> {
+    const { db } = await this.getModel()
+    const sql = type
+      ? 'SELECT id, title, body, author, created_at, reactions, type FROM items WHERE type = ? ORDER BY RANDOM() LIMIT 1'
+      : 'SELECT id, title, body, author, created_at, reactions, type FROM items ORDER BY RANDOM() LIMIT 1'
+    const rows = readItemRows(db, sql, type ? [type] : [])
+    if (rows.length === 0) return null
+    const tagsMap = queryTagsForIds(db, [rows[0].id])
+    return rowToItem(rows[0], tagsMap.get(rows[0].id) ?? [])
+  }
+
+  async getItemById(id: string): Promise<IKfcItem | null> {
+    const { db } = await this.getModel()
+    const rows = readItemRows(
+      db,
+      'SELECT id, title, body, author, created_at, reactions, type FROM items WHERE id = ?',
+      [id],
+    )
+    if (rows.length === 0) return null
+    const tagsMap = queryTagsForIds(db, [id])
+    return rowToItem(rows[0], tagsMap.get(id) ?? [])
+  }
+
+  async getStats(): Promise<Summary> {
+    const { summary } = await this.getModel()
+    if (summary) {
+      const contributors = (summary.contributors || []).map(toContributor)
+      return {
+        totalItems: summary.totalItems,
+        totalContributors: summary.totalContributors,
+        months: summary.months || [],
+        contributors,
+        topContributors: contributors.slice(0, 10),
+        updatedAt: summary.updatedAt || new Date().toISOString(),
+      }
+    }
+    // 没有 summary：从 db 兜底
+    const contributors = await this.getContributors()
+    const total = await this.getContributorsCount()
+    return {
+      totalItems: contributors.reduce((acc, c) => acc + c.count, 0),
+      totalContributors: total,
+      months: [],
+      contributors,
+      topContributors: contributors.slice(0, 10),
+      updatedAt: new Date().toISOString(),
+    }
+  }
+
+  async getContributorsCount(): Promise<number> {
+    const { db, summary } = await this.getModel()
+    if (summary) return summary.totalContributors
+    return readScalar<number>(db, 'SELECT COUNT(DISTINCT author) FROM items')
+  }
+
+  async getTopTags(limit = 4): Promise<TopTag[]> {
+    const { db } = await this.getModel()
+    const stmt = db.prepare(
+      'SELECT tag, COUNT(*) AS c FROM item_tags GROUP BY tag ORDER BY c DESC, tag ASC LIMIT ?',
+    )
+    stmt.bind([limit] as never)
+    const out: TopTag[] = []
+    while (stmt.step()) {
+      const row = stmt.getAsObject() as { tag: string; c: number }
+      out.push({ tag: row.tag, count: row.c })
+    }
+    stmt.free()
+    return out
+  }
+
+  async searchItems(query: string, limit = 50): Promise<IKfcItem[]> {
+    const { db } = await this.getModel()
+    const q = `%${query.toLowerCase()}%`
+    const rows = readItemRows(
+      db,
+      'SELECT id, title, body, author, created_at, reactions, type FROM items WHERE LOWER(title) LIKE ? OR LOWER(body) LIKE ? ORDER BY created_at DESC LIMIT ?',
+      [q, q, limit],
+    )
+    const tagsMap = queryTagsForIds(
+      db,
+      rows.map((r) => r.id),
+    )
+    return rows.map((r) => rowToItem(r, tagsMap.get(r.id) ?? []))
+  }
+
+  async getContributors(): Promise<Contributor[]> {
+    const { db, summary } = await this.getModel()
+    if (summary?.contributors) {
+      return summary.contributors.map(toContributor)
+    }
+    const stmt = db.prepare(
+      'SELECT author, COUNT(*) AS c FROM items GROUP BY author ORDER BY c DESC, author ASC',
+    )
+    const out: Contributor[] = []
+    while (stmt.step()) {
+      const row = stmt.getAsObject() as { author: string; c: number }
+      out.push(toContributor({ username: row.author, count: row.c }))
+    }
+    stmt.free()
+    return out
+  }
+
+  async getTopContributors(limit = 10): Promise<Contributor[]> {
+    return (await this.getContributors()).slice(0, limit)
+  }
+
+  async getFeaturedItems(limit = 3, excludeId?: string): Promise<IKfcItem[]> {
+    const { db } = await this.getModel()
+    // 每作者一条最佳 text 段子，全局按 reactions+createdAt 排序取 limit
+    // 用窗口函数 ROW_NUMBER 找每作者最佳
+    const sql = `
+      WITH ranked AS (
+        SELECT id, title, body, author, created_at, reactions, type,
+          ROW_NUMBER() OVER (PARTITION BY author ORDER BY reactions DESC, created_at DESC) AS rn
+        FROM items
+        WHERE type = 'text' ${excludeId ? 'AND id <> ?' : ''}
+      )
+      SELECT id, title, body, author, created_at, reactions, type
+      FROM ranked
+      WHERE rn = 1
+      ORDER BY reactions DESC, created_at DESC
+      LIMIT ?
+    `
+    const params = excludeId ? [excludeId, limit] : [limit]
+    const rows = readItemRows(db, sql, params)
+    const tagsMap = queryTagsForIds(
+      db,
+      rows.map((r) => r.id),
+    )
+    return rows.map((r) => rowToItem(r, tagsMap.get(r.id) ?? []))
+  }
+
+  // 非接口方法：健康检查，用于自检 / fallback 触发
+  async healthCheck(): Promise<boolean> {
+    try {
+      const { db } = await this.getModel()
+      return readScalar<number>(db, 'SELECT COUNT(*) FROM items') > 0
+    } catch {
+      return false
+    }
+  }
+}


### PR DESCRIPTION
## 目的
默认读模型从 month JSON + 内存 records 切到 **sql.js 装载 `data/snapshot.sql`**，兑现 architecture §5「无正文索引 + 正文按需」承诺。承接 spike #4 的实测数据。

## 改动
- 新增 `SqlSnapshotProvider implements DataProvider`：拉 `snapshot.sql` + sql.js 内存 SQLite + 模块单例 + 5min TTL + graceful-degrade
- `getDataProvider()` 默认改为 SqlSnapshotProvider；保留 SnapshotProvider（JSON）+ NeonProvider 作降级（`DATA_PROVIDER=snapshot|neon`）
- `next.config.mjs` 加 `outputFileTracingIncludes` 把 sql-wasm.wasm 打进所有 lambda
- 17 个单测覆盖：author/type/tag/search 过滤、排序、分页、tags 数组、author 派生、getItemById、stats、topTags、search、featured、random、graceful-degrade、TTL

## 数据
spike #4 实测对比（278 条数据，hkg1 lambda）：
- 当前 SnapshotProvider cold ~1113ms
- SqlSnapshotProvider 预期 cold ~500-600ms（fetch 单文件 165KB + sql.js init + db.exec）
- warm 查询：作者过滤 18ms → ~0.5ms

## 测试计划
- [ ] tsc/vitest/build 本地全过 ✅（38/38）
- [ ] Vercel preview 部署成功
- [ ] preview curl `/authors/zkl2333` 200 + 含 hero + 列表 + 分页
- [ ] preview curl `/jokes` 200 + 列表正常
- [ ] preview curl `/jokes?tag=恋爱` 200 + tag 过滤正确（与生产 vme.im 同口径）
- [ ] preview curl `/leaderboard` 200
- [ ] preview curl `/api/items?author=zkl2333` total=125
- [ ] preview curl `/jokes/<id>` 200
- [ ] 实测 cold start vs warm 数据